### PR TITLE
Fixing missing 'falloff' value by adding the 'range' value to the data.

### DIFF
--- a/modules/hardpoints/fragment_cannon.json
+++ b/modules/hardpoints/fragment_cannon.json
@@ -325,6 +325,7 @@
       "piercing": 45,
       "power": 1.02,
       "pp": "Zachary Hudson",
+      "range": 3000,
       "rating": "C",
       "reload": 5,
       "roundspershot": 12,


### PR DESCRIPTION
This was a simple fix, the code that displays 'falloff' values, requires there to be a falloff and a range value in the data. This is true of Frag Cannons, but was missing the range value on the Pacifier. Adding the range value to the Pacifier data, causes the falloff and range values to be displayed.