### PR TITLE
Fixes the integrity boost provided by a 'Double Braced' experimental …

### DIFF
--- a/modifications/modifierActions.json
+++ b/modifications/modifierActions.json
@@ -342,7 +342,7 @@
     "optmass": 0.04
   },
   "special_fsd_toughened": {
-    "integrity": 0.15
+    "integrity": 0.25
   },
   "special_fsd_lightweight": {
     "mass": -0.1


### PR DESCRIPTION
…being applied to an FSD from 0.15 to 0.25 which is correct.